### PR TITLE
Modifications under Xcode 4 and IOS 6

### DIFF
--- a/cocoa/SHDataMatrixReader.h
+++ b/cocoa/SHDataMatrixReader.h
@@ -21,14 +21,12 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 /* $Id$ */
 
-#if TARGET_OS_IPHONE
-#import <UIKit/UIKit.h>
-#else
+#if ! TARGET_OS_IPHONE
 #import <Cocoa/Cocoa.h>
 #endif
 
 @interface SHDataMatrixReader : NSObject {
-
+    
 }
 #pragma mark Allocation
 + (id)sharedDataMatrixReader;

--- a/cocoa/SHDataMatrixReader.m
+++ b/cocoa/SHDataMatrixReader.m
@@ -54,10 +54,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	return self;
 }
 
-- (void)dealloc {
-	[super dealloc];
-}
-
 #pragma mark Instance
 #if TARGET_OS_IPHONE
 - (NSString *)decodeBarcodeFromImage:(UIImage *)image {
@@ -69,11 +65,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
     NSData * imageData = [self _ARGB8DataForImage:image];
 	// Create dmtx image.
-	DmtxImage *dmtxImage = dmtxImageCreate([imageData bytes], 500, 500, DmtxPack32bppXRGB);
-	if(dmtxImage == NULL) {
-        [imageData release];
+	DmtxImage *dmtxImage = dmtxImageCreate((unsigned char*)[imageData bytes], 500, 500, DmtxPack32bppXRGB);
+	if(dmtxImage == NULL)
 		return nil;
-    }
 
 	// Initialize dmtx decode struct for image.
 	DmtxDecode *dmtxDecode = dmtxDecodeCreate(dmtxImage, 1);
@@ -95,7 +89,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 		if(dmtxMessage != NULL) {
 			// Convert C string to NSString.
-			NSString *message = [NSString stringWithCString:(const char*)dmtxMessage->output length:(NSUInteger)dmtxMessage->outputIdx];
+            NSString *message = [[NSString alloc] initWithBytes:dmtxMessage->output length:(NSUInteger)dmtxMessage->outputIdx encoding:NSASCIIStringEncoding];
 			[messages addObject:message];
 
 			// Free dmtx message memory.
@@ -184,5 +178,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 	return imageData;
 }
+
+#if ! __has_feature(objc_arc)
+- (void)dealloc {
+    [super dealloc];
+}
+#endif
 
 @end


### PR DESCRIPTION
Disable non ARC functions if ARC is enabled
Warnings removed (deprecation, cast)
